### PR TITLE
Fixed CalculateNearbyAirports() to work on iOS

### DIFF
--- a/Model/BusinessLogic.cs
+++ b/Model/BusinessLogic.cs
@@ -228,7 +228,6 @@ public partial class BusinessLogic(IDatabaseSupa db) : IBusinessLogic
 
     public async Task<ObservableCollection<VisitedAirport>> GetVisitedAirports()
     {
-        Console.WriteLine($"I am being called at {DateTime.Now}");
         try
         {
             ObservableCollection<VisitedAirport> airports = await db.SelectAllVisitedAirports(); // grab all the airports

--- a/Model/Database.cs
+++ b/Model/Database.cs
@@ -74,7 +74,6 @@ public partial class DatabaseSupa : IDatabaseSupa
             using StreamReader reader = new StreamReader(stream);
             string jsonAirports = await reader.ReadToEndAsync();
             wisconsinAirportsMap = JsonSerializer.Deserialize<Dictionary<String, WisconsinAirport>>(jsonAirports)!;
-            Console.WriteLine($"Here is one airport (KATW):{wisconsinAirportsMap["KATW"]}");
         }
         catch (Exception ex)
         {

--- a/Model/NearbyAirportBusinessLogic.cs
+++ b/Model/NearbyAirportBusinessLogic.cs
@@ -34,38 +34,43 @@ public partial class BusinessLogic
     /// <param name="sourceAirport">The airport whose location to use as reference.</param>
     /// <param name="maxMiles">How far the desired airports are to be from the sourceAirport.</param>
     /// <returns></returns>
-    public void CalculateNearbyAirports(WisconsinAirport sourceAirport, int maxMiles)
+public void CalculateNearbyAirports(WisconsinAirport sourceAirport, int maxMiles)
+{
+    Dictionary<string, int> idToMiles = new();
+    List<WisconsinAirport> tempNearbyAirports = new();
+
+    ObservableCollection<WisconsinAirport> allAirports = GetWisconsinAirports();
+
+    foreach (WisconsinAirport destinationAirport in allAirports)    // why aren't we using a dictionary here??
     {
-        NearbyAirports.Clear();
-        Dictionary<string, int> idToMiles = new();
+        WisconsinAirport? destinationAirportCoordinates = WisconsinAirports.FirstOrDefault(
+            airport => airport?.Id == destinationAirport.Id && airport.Id != sourceAirport.Id, null
+        );
 
-        ObservableCollection<WisconsinAirport> allAirports = GetWisconsinAirports();
-
-        foreach (WisconsinAirport destinationAirport in allAirports)
+        if (destinationAirportCoordinates != null)
         {
-            WisconsinAirport? destinationAirportCoordinates = WisconsinAirports.FirstOrDefault(
-                airport => airport?.Id == destinationAirport.Id && airport.Id != sourceAirport.Id, null
+            double distanceInMiles = GetDistanceFromAirportCoordinates(
+                sourceAirport,
+                destinationAirportCoordinates
             );
-
-            if (destinationAirportCoordinates != null)
+            if (distanceInMiles < maxMiles)
             {
-                double distanceInMiles = GetDistanceFromAirportCoordinates(
-                    sourceAirport,
-                    destinationAirportCoordinates
-                );
-                if (distanceInMiles < maxMiles)
-                {
-                    NearbyAirports.Add(destinationAirport);
-                    idToMiles[destinationAirport.Id] = (int)Math.Round(distanceInMiles);
-                }
+                tempNearbyAirports.Add(destinationAirport);
+                idToMiles[destinationAirport.Id] = (int)Math.Round(distanceInMiles);
             }
         }
-
-        IsNearbyAirportsHeaderVisible = NearbyAirports.Count > 0;
-
-        AirportToMilesConverter
-            .ConvertAll(idToMiles); // calling convert all to populate _idToMiles with the (id, distance) entries
     }
+
+    AirportToMilesConverter.ConvertAll(idToMiles); // converter now has distances to display
+
+    NearbyAirports.Clear();
+    foreach (var airport in tempNearbyAirports)
+    {
+        NearbyAirports.Add(airport);
+    }
+
+    IsNearbyAirportsHeaderVisible = NearbyAirports.Count > 0; // no airports? no headers necessary
+}
 
     public static double GetDistanceFromAirportCoordinates(
         WisconsinAirport sourceAirport,

--- a/Model/NearbyAirports/AirportToMilesConverter.cs
+++ b/Model/NearbyAirports/AirportToMilesConverter.cs
@@ -22,10 +22,8 @@ public class AirportToMilesConverter: IValueConverter
     
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        Console.WriteLine("Greetings from Convert()");
         if (value is WisconsinAirport airport)
         {
-            Console.WriteLine($"Processing {airport.Id}");
             // It is possible for Convert to be called before ConvertAll, so the guard is necessary.
             bool found = _idToMiles.TryGetValue(airport.Id, out var airportMiles);
             if (found)

--- a/UI/EnterAirportDetailsPopup.xaml.cs
+++ b/UI/EnterAirportDetailsPopup.xaml.cs
@@ -20,7 +20,6 @@ public partial class EnterAirportDetailsPopup : Popup
     public EnterAirportDetailsPopup(VisitedAirport? airport)
     {
         InitializeComponent();
-        Console.WriteLine("Popup Opened");
         if (airport != null) // only null if it's an edit
         {
             isEdit = true; // technically we could use whether airportToEditId is null to check this, but this is more clear

--- a/UI/MainTabbedPage.xaml.cs
+++ b/UI/MainTabbedPage.xaml.cs
@@ -18,21 +18,5 @@ public partial class MainTabbedPage : TabbedPage
 
 	}
 
-// protected override void OnCurrentPageChanged()
-// {
-//     base.OnCurrentPageChanged();
 
-//     var selectedTab = CurrentPage; // CurrentPage gives the currently selected tab
-//     if (selectedTab != null)
-//     {
-//         Console.WriteLine($"Selected Tab: {selectedTab.Title}");
-
-//         // Example: Perform actions based on the selected tab
-//         if (selectedTab is NavigationPage navPage && navPage.CurrentPage is MapPageSimple mapPage)
-//         {
-//            Console.WriteLine("Got to here"); 
-// 		   mapPage.InitializeMap();
-//         }
-//     }
-// }
 }

--- a/UI/MapPageSimple.xaml.cs
+++ b/UI/MapPageSimple.xaml.cs
@@ -31,12 +31,10 @@ public partial class MapPageSimple : ContentPage
 		map.Navigator.ZoomToBox(wisconsinBox);
 		MyMapControl.Map = map;
 
-		Console.WriteLine($"Dimensions are {Width} x {Height}");
 	}
 	protected override void OnSizeAllocated(double width, double height)
 	{
 		base.OnSizeAllocated(width, height);
-		Console.WriteLine($"MapControl actual size: Width={MyMapControl.Width}, Height={MyMapControl.Height}");
 	}
 
 }

--- a/UI/NearbyAirportsPage.xaml
+++ b/UI/NearbyAirportsPage.xaml
@@ -92,7 +92,7 @@
                                     Text="{
                                         Binding ., 
                                         Converter={StaticResource AirportToMilesConverter},
-                                        StringFormat='1{0:F1} NM'
+                                        StringFormat='{0:F1} NM'
                                     }" />
                                 <!--  <Image
                                     VerticalOptions="Center"


### PR DESCRIPTION
Addressed an interesting question of timing, code worked correctly on Android but not iOS. We had to guarantee that ConvertAll() was called before any airports were added, because once any airport was added, iOS decided to trigger a redraw of the CollectionView. The original code called ConvertAll() after all the nearby airports had been added, and that was too late.

Fixed a typo in the CollectionView, an errant 1 was being printed in the distance column

Also deleted numerous Console.WriteLine() debugging statements

	modified:   Model/BusinessLogic.cs
	modified:   Model/Database.cs
	modified:   Model/NearbyAirportBusinessLogic.cs
	modified:   Model/NearbyAirports/AirportToMilesConverter.cs
	modified:   UI/EnterAirportDetailsPopup.xaml.cs
	modified:   UI/MainTabbedPage.xaml.cs
	modified:   UI/MapPageSimple.xaml.cs
	modified:   UI/NearbyAirportsPage.xaml